### PR TITLE
Parse threshold as integer

### DIFF
--- a/masscan_as_a_service/__main__.py
+++ b/masscan_as_a_service/__main__.py
@@ -61,7 +61,7 @@ def _args_parser() -> Dict[str, argparse.ArgumentParser]:
 
     parser_cleanup = subparsers.add_parser('cleanup')
     parser_cleanup.add_argument('-t', '--threshold',
-                                dest='threshold', type=str,
+                                dest='threshold', type=int,
                                 required=True,
                                 help='All VMs older then THRESHOLD seconds will be deleted.')
 


### PR DESCRIPTION
Value should represent number of seconds.

Currently it appears to be failing with:
```
src/masscan-as-a-service/masscan_as_a_service/vm_operator/hetzner_cloud_operator.py", line 55, in purge_old_vms
    if (datetime.now(pytz.utc) - timedelta(seconds=max_age)) > vm.created:
TypeError: unsupported type for timedelta seconds component: str
```